### PR TITLE
Add text stroke customization

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -207,6 +207,30 @@ canvas {
 
 .color-input {
     width: 60px;
+    vertical-align: middle; /* Align color inputs with labels */
+    margin-left: 5px; /* Add some space after the label */
+}
+
+.control-text label {
+    color: #FFF; /* Make labels visible */
+    font-size: 0.9em; /* Slightly smaller font for labels */
+    margin-left: 8px; /* Space before label */
+    margin-right: 3px; /* Space after label */
+    vertical-align: middle;
+}
+
+/* Specific styling for stroke width range input */
+.control-text input[type="range"][data-tool="strokeWidth"] {
+    width: 80px; /* Adjust width as needed */
+    vertical-align: middle;
+    margin-left: 5px; /* Add some space after the label */
+}
+
+/* General adjustments for inputs within control-text for tighter packing */
+.control-text input,
+.control-text select {
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 .fb-share-btn {
@@ -229,8 +253,9 @@ canvas {
     padding-top: 2px;
 }
 
-.text-input{
+.text-input {
     padding: 6px;
+    vertical-align: middle; /* Align text input with other controls */
 }
 
 /* Footer */

--- a/js/generator-controller.js
+++ b/js/generator-controller.js
@@ -44,8 +44,11 @@ function drawTxt(txt) {
     gCtx.font = txt.size + 'px ' + txt.fontFamily;
     gCtx.textAlign = txt.align;
     gCtx.fillStyle = txt.color;
-    gCtx.lineWidth = 3;
+    gCtx.lineWidth = 3; // This might be for the fillText "border" effect, or a leftover. Task specifies strokeWidth for strokeText.
     gCtx.fillText(txt.line, txt.x, txt.y);
+
+    gCtx.strokeStyle = txt.strokeColor;
+    gCtx.lineWidth = txt.strokeWidth;
     gCtx.strokeText(txt.line, txt.x, txt.y);
 }
 
@@ -71,8 +74,9 @@ function renderControls() {
         <button class="line-delete" onclick="onDeleteText(${idx})"><i class="fas trash fa-trash-alt"></i></button>
         <input class="text-input" type="text" data-tool="line" placeholder="${txt.line}" oninput="dynamicText(this,${idx})"/>
         <i class="fas fa-text-height"></i> <input type="range" value="${txt.size}"  min="10" step="2" data-tool="size" oninput="dynamicText(this ,${idx})">
-        <input type="color" class="color-input" value="${txt.color}" data-tool="color" oninput="dynamicText(this,${idx})">
-
+        <label for="fillColor">Fill:</label><input type="color" id="fillColor" class="color-input" value="${txt.color}" data-tool="color" oninput="dynamicText(this,${idx})">
+        <label for="strokeColor">Stroke:</label><input type="color" id="strokeColor" class="color-input" value="${txt.strokeColor}" data-tool="strokeColor" oninput="dynamicText(this,${idx})">
+        <label for="strokeWidth">Stroke Width:</label><input type="range" id="strokeWidth" value="${txt.strokeWidth}"  min="0" max="10" step="1" data-tool="strokeWidth" oninput="dynamicText(this ,${idx})">
 
           <i class="fas fa-font"></i>: 
          <select data-tool="fontFamily" oninput="dynamicText(this,${idx})">

--- a/js/generator-service.js
+++ b/js/generator-service.js
@@ -18,6 +18,8 @@ function createText(line, x, y) {
         align: 'left',
         color: '#FFFFFF',
         fontFamily: 'Impact',
+        strokeColor: '#000000',
+        strokeWidth: 1,
         x: x,
         y: y
     }

--- a/test-stroke.html
+++ b/test-stroke.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stroke Test</title>
+    <style>
+        body { display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background-color: #f0f0f0; }
+        canvas { border: 1px solid black; }
+    </style>
+</head>
+<body>
+    <canvas id="test-canvas" width="500" height="500"></canvas>
+
+    <script src="js/generator-utils.js"></script>
+    <script src="js/generator-service.js"></script>
+    <script src="js/generator-controller.js"></script>
+    <script>
+        // Mock gImg for drawCanvas to work without actual image loading if needed
+        // or ensure drawCanvas is robust enough.
+        // For this test, we will simulate a simple image background.
+        gImg = {
+            naturalWidth: 500,
+            naturalHeight: 500,
+            // A simple placeholder to avoid errors if drawImage is called directly
+            // In our case, drawImage in drawCanvas will use this.
+            // We'll also draw a background in the test script itself.
+        };
+
+        function testStrokeFeature() {
+            // 1. Initialize environment (simplified onInit)
+            userMemesSetting(); // Initializes gMemes
+
+            // Redefine gCanvas and gCtx for this test page, as onInit() from controller might not target 'test-canvas'
+            gCanvas = document.getElementById('test-canvas');
+            if (!gCanvas) {
+                console.error('Test canvas not found!');
+                return;
+            }
+            gCtx = gCanvas.getContext('2d');
+
+            // Draw a simple background for the test
+            gCtx.fillStyle = 'lightgray';
+            gCtx.fillRect(0, 0, gCanvas.width, gCanvas.height);
+
+            let firstText = getMemes().txts[0];
+            if (!firstText) {
+                console.error('No first text line found in gMemes.');
+                return;
+            }
+
+            // 2. Draw initial text (optional, to see "before" state if desired, but drawCanvas will do it)
+            // For simplicity, we'll let the first drawCanvas handle initial drawing.
+
+            // 3. Programmatically update strokeColor and strokeWidth for the first text line
+            console.log('Updating stroke properties for the first text line...');
+            firstText.strokeColor = '#FF0000'; // Red
+            firstText.strokeWidth = 5;
+
+            // 4. Call drawCanvas() to reflect changes
+            // Ensure drawCanvas uses the gMemes modified above.
+            // drawCanvas internally gets gMemes via getMemes()
+            console.log('Calling drawCanvas() to apply changes...');
+            drawCanvas(); // This will draw the image (mocked here) and all texts
+
+            // 5. Log completion message
+            console.log(`Test complete. Stroke color for first line set to: ${firstText.strokeColor}, stroke width to: ${firstText.strokeWidth}. Please visually inspect the canvas.`);
+            console.log('The first text line should now have a red stroke of width 5.');
+        }
+
+        // Run the test after the page loads and scripts are parsed
+        window.onload = testStrokeFeature;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This change introduces the ability for you to customize the stroke color and width of the text on memes.

Features:
- Added `strokeColor` and `strokeWidth` properties to text objects.
- Included new input controls in the UI for modifying stroke color (color picker) and stroke width (range slider).
- Updated the canvas drawing logic to apply these new stroke properties.
- Added basic CSS styling for the new controls to match the existing UI.

A manual test page (`test-stroke.html`) was created to verify this functionality.